### PR TITLE
Fixing the mvn based image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,12 +17,13 @@
 # under the License.
 #
 
-FROM openjdk:8-jdk
+FROM openjdk:11-jdk
 
 ARG BENCHMARK_TARBALL
 
 ADD ${BENCHMARK_TARBALL} /
 
 RUN mv openmessaging-benchmark-* /benchmark
+RUN ln -s /benchmark /tmp/src
 
 WORKDIR /benchmark

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -93,6 +93,13 @@
                                 <BENCHMARK_TARBALL>target/package-${project.version}-bin.tar.gz</BENCHMARK_TARBALL>
                             </buildArgs>
                         </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.activation</groupId>
+                                <artifactId>activation</artifactId>
+                                <version>1.1.1</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Also switched to JDK 11 to match our current practice.