### PR TITLE
changing the default key distribution

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -29,7 +29,7 @@ public class Workload {
     /** Number of partitions each topic will contain */
     public int partitionsPerTopic;
 
-    public KeyDistributorType keyDistributor = KeyDistributorType.NO_KEY;
+    public KeyDistributorType keyDistributor = KeyDistributorType.KEY_ROUND_ROBIN;
 
     public int messageSize;
 


### PR DESCRIPTION
NO KEY does not properly utilize partitions.