### PR TITLE
collecting all connection samples

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/TestResult.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/TestResult.java
@@ -62,6 +62,7 @@ public class TestResult {
     public List<Double> endToEndLatency999pct = new ArrayList<>();
     public List<Double> endToEndLatency9999pct = new ArrayList<>();
     public List<Double> endToEndLatencyMax = new ArrayList<>();
+    public List<Double> connectionCount = new ArrayList<>();
 
     public Map<Double, Double> aggregatedEndToEndLatencyQuantiles = new TreeMap<>();
 
@@ -77,5 +78,4 @@ public class TestResult {
     public Double maxSustainableRate;
     public long aggregatedPublishErrors;
     public long aggregatedConsumerErrors;
-    public double connectionCount;
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -525,6 +525,7 @@ public class WorkloadGenerator implements AutoCloseable {
             result.endToEndLatency999pct.add(microsToMillis(stats.endToEndLatency.getValueAtPercentile(99.9)));
             result.endToEndLatency9999pct.add(microsToMillis(stats.endToEndLatency.getValueAtPercentile(99.99)));
             result.endToEndLatencyMax.add(microsToMillis(stats.endToEndLatency.getMaxValue()));
+            result.connectionCount.add(counterStats.connectionCount);
 
             if (now >= testEndTime && !needToWaitForBacklogDraining) {
                 boolean complete = false;
@@ -586,7 +587,6 @@ public class WorkloadGenerator implements AutoCloseable {
 
                 result.aggregatedPublishErrors = counterStats.publishErrors;
                 result.aggregatedConsumerErrors = counterStats.consumerErrors;
-                result.connectionCount = counterStats.connectionCount;
                 break;
             }
         }


### PR DESCRIPTION
This allows the downstream logic to fully reason over the connections - for example I want the true max to be reported by the instance profiler.